### PR TITLE
Clarify shared-runtime proposal review boundary

### DIFF
--- a/.agents/skills/proposal-agent/references/task-proposal-rubric.md
+++ b/.agents/skills/proposal-agent/references/task-proposal-rubric.md
@@ -261,9 +261,12 @@ Evaluate all nine gates before deciding. Do not stop at the first concern.
   that depends on a future or unsupported Harness capability, separate verifier
   image, or clean-Base Judge does not count. If such a capability is essential
   to the evaluation boundary, this gate fails.
-- Fail this gate only when the design leaves a credible direct path to evaluation
-  leakage or reward hacking, or when the exposure and safeguards are materially
-  undefined.
+- Treat shared Work/Judge snapshots and Work-root control of the inherited
+  interpreter or libraries as platform-wide residual limitations. Do not reject
+  a proposal solely for those properties or require arbitrary-root isolation.
+- Still fail for concrete task-specific paths to evaluation leakage, evaluator
+  or score tampering, or fabricated results, and for materially undefined
+  exposure or safeguards.
 
 ### 8. Data and Network Boundaries
 


### PR DESCRIPTION
Clarify that shared Work/Judge snapshots and Work-root control of inherited runtimes are platform-wide residual limitations, not standalone proposal rejection reasons. Preserve rejection for task-specific leakage, evaluator/score tampering, fabricated results, and undefined safeguards.

Matches the two RSI-Skills rubric copies in commit 80fcd7d. No Harness, workflow, proposal, or research-contract changes.

Validation: six relevant Public checks and seven Skills rubric checks passed; all three rubric files are byte-identical. An existing CONTRIBUTING wording test fails because it still expects "about 1 hour" while the document uses "<= 1h"; neither file is changed here.