### PR TITLE
Fix rubric repository evidence parsing for proposal tables

### DIFF
--- a/checks/rubric_review.py
+++ b/checks/rubric_review.py
@@ -183,6 +183,7 @@ _PATH_FIELD_RE = re.compile(
     r"(?im)^[ \t]*(?:[-*][ \t]*)?Repository[ \t]+evidence[ \t]+paths?"
     r"[^:\n]*:[ \t]*(?P<value>[^\n]*)$"
 )
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]\n]+)\]\([^\)\n]+\)")
 _RELEVANT_TREE_PATH_RE = re.compile(
     r"(?i)(?:^|/)(?:readme(?:\.[^/]*)?|configs?|experiments?|scripts?|"
     r"train(?:ing)?|eval(?:uation)?|benchmarks?|recipes?)(?:/|\.|_|-|$)"
@@ -234,7 +235,27 @@ def fetch_image_blocks(urls: list[str]) -> list[dict]:
     return blocks
 
 
+def _repository_field_value(text: str, pattern: re.Pattern[str]) -> str | None:
+    """Read a legacy field line or a field/value pair in a Markdown table."""
+    match = pattern.search(text)
+    if match:
+        return match.group("value")
+    for line in text.splitlines():
+        cells = re.split(r"(?<!\\)\|", line)
+        for label, value in zip(cells, cells[1:]):
+            label = label.strip(" \t`*_").rstrip(":")
+            match = pattern.fullmatch(f"{label}: {value.strip()}")
+            if match:
+                return match.group("value")
+    return None
+
+
 def _clean_field_value(value: str) -> str | None:
+    # The template allows branch provenance before the resolved immutable SHA.
+    sha = re.search(r"\b[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?\b", value)
+    if sha:
+        return sha.group()
+    value = _MARKDOWN_LINK_RE.sub(r"\1", value)
     cleaned = value.strip().strip("`*_ ")
     if not cleaned or cleaned.lower() in {"-", "n/a", "none", "tbd"}:
         return None
@@ -253,9 +274,9 @@ def _clean_repo_path(value: str) -> str | None:
 
 def parse_repository_reference(text: str) -> RepositoryReference | None:
     """Parse the official GitHub repository, exact ref, and evidence paths."""
-    repository_field = _REPOSITORY_URL_FIELD_RE.search(text)
-    if repository_field:
-        repo_match = _GITHUB_REPO_RE.search(repository_field.group("value"))
+    repository_field = _repository_field_value(text, _REPOSITORY_URL_FIELD_RE)
+    if repository_field is not None:
+        repo_match = _GITHUB_REPO_RE.search(repository_field)
         if repo_match is None:
             return None
     else:
@@ -276,16 +297,23 @@ def parse_repository_reference(text: str) -> RepositoryReference | None:
     owner = repo_match.group("owner")
     repo = repo_match.group("repo").removesuffix(".git")
 
-    ref_match = _REF_FIELD_RE.search(text)
-    ref = _clean_field_value(ref_match.group("value")) if ref_match else None
+    ref_value = _repository_field_value(text, _REF_FIELD_RE)
+    ref = _clean_field_value(ref_value) if ref_value is not None else None
 
     paths: list[str] = []
-    path_match = _PATH_FIELD_RE.search(text)
-    if path_match:
-        for item in re.split(r"[,;]", path_match.group("value")):
-            path = _clean_repo_path(item)
-            if path and path not in paths:
-                paths.append(path)
+    path_value = _repository_field_value(text, _PATH_FIELD_RE)
+    if path_value:
+        legacy_paths = _PATH_FIELD_RE.search(text) is not None
+        # Linked files are collected below after matching their repository/ref.
+        path_value = _MARKDOWN_LINK_RE.sub("", path_value)
+        for item in re.split(r"[,;]|<br\s*/?>", path_value, flags=re.IGNORECASE):
+            quoted_paths = re.findall(r"`([^`\n]*[/.][^`\n]+)`", item)
+            for candidate in quoted_paths or [item]:
+                if not (legacy_paths or quoted_paths) and re.search(r"\s", candidate.strip()):
+                    continue
+                path = _clean_repo_path(candidate)
+                if path and path not in paths:
+                    paths.append(path)
 
     for blob_match in _GITHUB_BLOB_RE.finditer(text):
         blob_repo = blob_match.group("repo").removesuffix(".git")

--- a/checks/test_rubric_review.py
+++ b/checks/test_rubric_review.py
@@ -82,6 +82,69 @@ https://github.com/example-org/example-repo/blob/0123456789abcdef/evals/run_eval
     )
 
 
+@pytest.mark.parametrize("section_column", ["", "Research Question | "])
+def test_parse_repository_reference_reads_table_with_pinned_links(review, section_column):
+    proposal = f"""
+Contributor repository: https://github.com/contributor/unrelated
+
+| {section_column}Repository URL | Official source: [TRL](https://github.com/huggingface/trl) |
+| {section_column}Exact commit/tag | Requested ref: `main`; pinned to immutable commit [`42e1cdbafa06d9f7a1c2a7d6cdd98329a55b569f`](https://github.com/huggingface/trl/commit/42e1cdbafa06d9f7a1c2a7d6cdd98329a55b569f). |
+| Reference Baseline | Repository evidence paths | [`trl/trainer/utils.py`](https://github.com/huggingface/trl/blob/42e1cdbafa06d9f7a1c2a7d6cdd98329a55b569f/trl/trainer/utils.py) defines `RepeatSampler`; [`trl/trainer/grpo_trainer.py`](https://github.com/huggingface/trl/blob/42e1cdbafa06d9f7a1c2a7d6cdd98329a55b569f/trl/trainer/grpo_trainer.py) installs the sampler. |
+"""
+
+    reference = review.parse_repository_reference(proposal)
+
+    assert reference == review.RepositoryReference(
+        "huggingface",
+        "trl",
+        "42e1cdbafa06d9f7a1c2a7d6cdd98329a55b569f",
+        ("trl/trainer/utils.py", "trl/trainer/grpo_trainer.py"),
+    )
+
+
+@pytest.mark.parametrize(
+    "ref_value",
+    [
+        "`v1.2.3`",
+        "[v1.2.3](https://github.com/right-org/right-repo/tree/v1.2.3)",
+    ],
+)
+def test_parse_repository_reference_reads_table_paths_and_tag(review, ref_value):
+    proposal = f"""
+| Field | Value |
+| --- | --- |
+| **Repository URL** | https://github.com/right-org/right-repo |
+| Exact commit/tag | {ref_value} |
+| Repository evidence paths | `configs/train.yaml`<br>scripts/train.py; `README.md`; Evaluator: `evals/run.py` returns `score`. |
+"""
+
+    assert review.parse_repository_reference(proposal) == review.RepositoryReference(
+        "right-org",
+        "right-repo",
+        "v1.2.3",
+        ("configs/train.yaml", "scripts/train.py", "README.md", "evals/run.py"),
+    )
+
+
+@pytest.mark.parametrize(
+    "path_field",
+    [
+        "Repository evidence paths: docs/model card.md",
+        "Repository evidence paths: `docs/model card.md`",
+        "Repository evidence paths: docs/model%20card.md",
+        "| Repository evidence paths | `docs/model card.md` |",
+        "| Repository evidence paths | docs/model%20card.md |",
+    ],
+)
+def test_parse_repository_reference_preserves_spaces_in_file_names(review, path_field):
+    proposal = (
+        "Repository URL: https://github.com/right-org/right-repo\n"
+        f"Exact commit/tag: main\n{path_field}\n"
+    )
+
+    assert review.parse_repository_reference(proposal).paths == ("docs/model card.md",)
+
+
 def test_parse_repository_reference_returns_none_without_supported_github_url(review):
     assert review.parse_repository_reference("No repository has been selected.") is None
 
@@ -218,7 +281,8 @@ def encoded_file(text: str) -> dict:
     }
 
 
-def test_fetch_repository_evidence_reads_declared_files_and_repo_tree(review):
+@pytest.mark.parametrize("table", [False, True])
+def test_fetch_repository_evidence_reads_declared_files_and_repo_tree(review, table):
     api = "https://api.github.com/repos/example-org/example-repo"
     resolved_sha = "a" * 40
     responses = {
@@ -252,12 +316,16 @@ def test_fetch_repository_evidence_reads_declared_files_and_repo_tree(review):
         ): encoded_file("def train(): pass"),
     }
     client = FakeGitHubClient(responses)
-    reference = review.RepositoryReference(
-        owner="example-org",
-        repo="example-repo",
-        ref="0123456789abcdef",
-        paths=("configs/train.yaml", "scripts/train.py"),
+    fields = (
+        ("Repository URL", "https://github.com/example-org/example-repo"),
+        ("Exact commit/tag", "0123456789abcdef"),
+        ("Repository evidence paths", "configs/train.yaml, scripts/train.py"),
     )
+    proposal = "\n".join(
+        f"| Section | {field} | {value} |" if table else f"- {field}: {value}"
+        for field, value in fields
+    )
+    reference = review.parse_repository_reference(proposal)
 
     evidence = review.fetch_repository_evidence(reference, client=client)
 


### PR DESCRIPTION
This is an automation fix, not a benchmark task submission. This description was prepared with Codex at the contributor's request.

The proposal-agent template uses Markdown tables, but the rubric evidence parser only recognized legacy field lines. Discussion #61 consequently lost its declared commit and all seven source paths during initial review.

- Read repository URL, exact ref, and evidence paths from two- and three-column tables while retaining legacy field support.
- Prefer the declared immutable SHA over preceding branch provenance; handle linked refs and source paths without collecting surrounding prose as filenames.
- Preserve quoted and URL-encoded filenames containing spaces. No changes to skills, rubric standards, workflow triggers, or task publication.

Validation: the existing Discussion CI suite passes locally (225 tests). The original #61 proposal now resolves to its declared repository, exact SHA, and all seven source paths. No live Discussion was triggered and no Docker/GPU execution was performed for this fix.

Known unrelated baseline issue: checks/test_rubric_review_service_contract.py references the removed tools/rubric-review-service. It fails identically on unchanged main and is not part of the current Discussion CI test list; this PR leaves it unchanged.