### PR TITLE
fix: post Discussion queue notices after task dispatch

### DIFF
--- a/.github/workflows/discussion-automation-checks.yml
+++ b/.github/workflows/discussion-automation-checks.yml
@@ -32,6 +32,7 @@ jobs:
             python -m pytest -q \
             checks/test_discussion_review_workflow.py \
             checks/test_discussion_task_dispatch_workflow.py \
+            checks/test_task_queue_notice_workflows.py \
             checks/test_discussion_task_dispatch.py \
             checks/test_proposal_pass_dispatch.py \
             checks/test_proposal_review_marker.py \

--- a/.github/workflows/discussion-review.yml
+++ b/.github/workflows/discussion-review.yml
@@ -325,6 +325,7 @@ jobs:
           permission-contents: write
 
       - name: Dispatch passed proposal privately
+        id: task-dispatch
         if: steps.review.outputs.decision == 'Pass' && steps.publish-review.outcome == 'success' && steps.publish-review.outputs.review_comment_id != '' && steps.dispatch-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.dispatch-token.outputs.token }}
@@ -352,6 +353,22 @@ jobs:
 
           gh api --method POST /repos/RSI-Index/RSI-Skills/dispatches \
             --input proposal-pass-request.json
+
+      - name: Post task queue notice
+        if: steps.task-dispatch.outcome == 'success' && steps.comment-token.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.comment-token.outputs.token }}
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          gh api graphql \
+            -f query='mutation($discussionId: ID!, $body: String!) {
+              addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                comment { id url }
+              }
+            }' \
+            -f discussionId="$DISCUSSION_ID" \
+            -f body='⏳ Your task is queued and will start automatically when a runner is available. No action is needed.'
 
       - name: Create failure comment Discussion App token
         id: failure-token

--- a/.github/workflows/discussion-task-dispatch.yml
+++ b/.github/workflows/discussion-task-dispatch.yml
@@ -104,9 +104,26 @@ jobs:
           PY
 
       - name: Dispatch privately
+        id: task-dispatch
         if: steps.gate.outputs.candidate == 'true' && (steps.gate.outputs.is_author == 'true' || steps.owner-gate.outputs.is_owner == 'true')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api --method POST /repos/RSI-Index/RSI-Skills/dispatches \
             --input repository-dispatch.json
+
+      - name: Post task queue notice
+        if: steps.task-dispatch.outcome == 'success' && steps.ack-token.outcome == 'success' && steps.gate.outputs.command == 'task'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.ack-token.outputs.token }}
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          gh api graphql \
+            -f query='mutation($discussionId: ID!, $body: String!) {
+              addDiscussionComment(input: { discussionId: $discussionId, body: $body }) {
+                comment { id url }
+              }
+            }' \
+            -f discussionId="$DISCUSSION_ID" \
+            -f body='⏳ Your task is queued and will start automatically when a runner is available. No action is needed.'

--- a/checks/test_discussion_review_workflow.py
+++ b/checks/test_discussion_review_workflow.py
@@ -99,9 +99,7 @@ def test_review_workflow_replaces_only_current_progress_with_generic_failure():
     assert failure["env"]["PROGRESS_COMMENT_ID"] == (
         "${{ steps.progress.outputs.comment_id }}"
     )
-    assert steps.index(failure_token) == (
-        steps.index(step_named("Dispatch passed proposal privately")) + 1
-    )
+    assert steps.index(failure_token) > steps.index(step_named("Dispatch passed proposal privately"))
     assert steps.index(failure) == steps.index(failure_token) + 1
     assert "Proposal review failed before completion" in failure["run"]
     assert "updateDiscussionComment" in failure["run"]

--- a/checks/test_task_queue_notice_workflows.py
+++ b/checks/test_task_queue_notice_workflows.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).parent.parent / ".github/workflows"
+ENTRIES = (
+    ("discussion-task-dispatch.yml", "dispatch", "Dispatch privately", "ack-token"),
+    (
+        "discussion-review.yml",
+        "review",
+        "Dispatch passed proposal privately",
+        "comment-token",
+    ),
+)
+
+
+def notice_steps(filename: str, job: str) -> tuple[list[dict], dict]:
+    workflow = yaml.load((WORKFLOWS / filename).read_text(), Loader=yaml.BaseLoader)
+    assert workflow["jobs"][job]["runs-on"] == "ubuntu-latest"
+    steps = workflow["jobs"][job]["steps"]
+    notices = [step for step in steps if step.get("name") == "Post task queue notice"]
+    assert len(notices) == 1, (
+        "Queued tasks need a notice before a W2 runner is available"
+    )
+    return steps, notices[0]
+
+
+@pytest.mark.parametrize("filename,job,dispatch_name,token", ENTRIES)
+def test_queue_notice_is_gated_on_successful_task_dispatch(
+    filename, job, dispatch_name, token
+):
+    steps, notice = notice_steps(filename, job)
+    dispatch = next(step for step in steps if step.get("name") == dispatch_name)
+    assert dispatch["id"] == "task-dispatch"
+    assert steps.index(notice) == steps.index(dispatch) + 1
+    expected_gate = f"steps.task-dispatch.outcome == 'success' && steps.{token}.outcome == 'success'"
+    if job == "dispatch":
+        expected_gate += " && steps.gate.outputs.command == 'task'"
+    assert notice["if"] == expected_gate
+    assert notice["continue-on-error"] == "true"
+    assert notice["env"] == {
+        "GH_TOKEN": "${{ steps." + token + ".outputs.token }}",
+        "DISCUSSION_ID": "${{ github.event.discussion.node_id }}",
+    }
+
+
+@pytest.mark.parametrize("filename,job,dispatch_name,token", ENTRIES)
+def test_queue_notice_posts_one_new_comment_without_modifying_history(
+    filename, job, dispatch_name, token, tmp_path
+):
+    _, notice = notice_steps(filename, job)
+    captured = tmp_path / "requests.jsonl"
+    gh = tmp_path / "gh"
+    gh.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        'with open(os.environ["CAPTURED_REQUESTS"], "a") as stream:\n'
+        '    stream.write(json.dumps(sys.argv[1:]) + "\\n")\n'
+    )
+    gh.chmod(0o755)
+    result = subprocess.run(
+        ["bash", "-e", "-c", notice["run"]],
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "GH_TOKEN": "test-token",
+            "DISCUSSION_ID": "D_queue_notice",
+            "CAPTURED_REQUESTS": str(captured),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    requests = [json.loads(line) for line in captured.read_text().splitlines()]
+    assert len(requests) == 1
+    args = requests[0]
+    assert args[:2] == ["api", "graphql"]
+    fields = dict(
+        args[index + 1].split("=", 1) for index, arg in enumerate(args) if arg == "-f"
+    )
+    assert fields["discussionId"] == "D_queue_notice"
+    assert "addDiscussionComment" in fields["query"]
+    assert "updateDiscussionComment" not in fields["query"]
+    assert "deleteDiscussionComment" not in fields["query"]
+    assert "Your task is queued" in fields["body"]
+    assert "will start automatically when a runner is available" in fields["body"]
+    assert "No action is needed." in fields["body"]


### PR DESCRIPTION
Workflow-only change; no benchmark task is added or modified. Description prepared by Codex.

- Post a new queue notice after successful automatic PASS or authorized /task dispatch, without waiting for W2 runner capacity.
- Preserve existing comments and later progress updates. Skip the notice for /reset and unsuccessful dispatches.
- Reuse existing scoped App tokens; notification failures remain nonfatal. No Skills or W2 configuration changes.
- Add queue-notice regression coverage to the Discussion automation CI checks.

Validation: all 229 Discussion automation tests passed; actionlint passed for all three changed workflows. No real Discussion or model run was triggered during testing.